### PR TITLE
Update promptWriter.ts to work in Deno 2

### DIFF
--- a/prompt_utils/src/promptWriter.ts
+++ b/prompt_utils/src/promptWriter.ts
@@ -6,7 +6,8 @@ export class PromptWriter {
   }
 
   public async write(text: string) {
-    await Deno.writeAll(this._stdout, new TextEncoder().encode(text));
+    await this._stdout.write( new TextEncoder().encode(text));
     return text;
   }
 }
+


### PR DESCRIPTION
Deno.writeAll does not exist in deno 2

Replaced Deno.writeAll with

await this._stdout.write( new TextEncoder().encode(text));

wich seem to work in Deno 1 and Deno 2
